### PR TITLE
Add Unempowered Starfire & Wrath module

### DIFF
--- a/analysis/druidbalance/src/CHANGELOG.tsx
+++ b/analysis/druidbalance/src/CHANGELOG.tsx
@@ -2,6 +2,7 @@ import { Zeboot, LeoZhekov, Sharrq, Tiboonn } from 'CONTRIBUTORS';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2021, 2, 21), 'Add modules for Starfire and Wrath to track unempowered casts', Tiboonn),
   change(date(2021, 1, 17), 'Update balance druid spells, Change all occurences of Solar Wrath to Wrath and Lunar Strike to Starfire', Tiboonn),
   change(date(2021, 1, 16), 'Added spell information for conduits', Tiboonn),
   change(date(2020, 12, 30), 'Updated to Typescript and added Integration Tests', Sharrq),

--- a/analysis/druidbalance/src/CombatLogParser.ts
+++ b/analysis/druidbalance/src/CombatLogParser.ts
@@ -10,7 +10,8 @@ import Abilities from './modules/Abilities';
 import CooldownThroughputTracker from './modules/features/CooldownThroughputTracker';
 import MoonfireUptime from './modules/features/MoonfireUptime';
 import SunfireUptime from './modules/features/SunfireUptime';
-import UnempoweredLunarStrike from './modules/features/UnempoweredLunarStrike';
+import UnempoweredStarfire from './modules/features/UnempoweredStarfire';
+import UnempoweredWrath from './modules/features/UnempoweredWrath';
 import EarlyDotRefreshes from './modules/features/EarlyDotRefreshes';
 import EarlyDotRefreshesInstants from './modules/features/EarlyDotRefreshesInstants';
 
@@ -36,7 +37,8 @@ class CombatLogParser extends MainCombatLogParser {
     cooldownThroughputTracker: CooldownThroughputTracker,
     moonfireUptime: MoonfireUptime,
     sunfireUptime: SunfireUptime,
-    unempoweredLunarStrike: UnempoweredLunarStrike,
+    unempoweredStarfire: UnempoweredStarfire,
+    unempoweredWrath: UnempoweredWrath,
     earlyDotRefreshes: EarlyDotRefreshes,
     earlyDotRefreshesInstants: EarlyDotRefreshesInstants,
 

--- a/analysis/druidbalance/src/integrationTests/example.test.ts.snap
+++ b/analysis/druidbalance/src/integrationTests/example.test.ts.snap
@@ -4210,29 +4210,30 @@ exports[`Balance Druid integration test: example log ThroughputStatisticGroup ma
 </div>
 `;
 
-exports[`Balance Druid integration test: example log UnempoweredLunarStrike matches the suggestions snapshot 1`] = `
+exports[`Balance Druid integration test: example log UnempoweredStarfire matches the suggestions snapshot 1`] = `
 Array [
   Object {
     "details": null,
     "icon": "spell_arcane_starfire",
-    "importance": "major",
+    "importance": "minor",
     "issue": <React.Fragment>
-      You cast 
+      You casted 
       17
        unempowered and non instant cast 
       <ForwardRef
         id={194153}
       />
        that hit less than 
-      3
-       targets. Always prioritize 
+      5
+       targets, outside the 
+      2
+       needed to get to 
       <ForwardRef
-        id={5176}
+        id={48518}
       />
-       as a filler when none of those conditions are met.
     </React.Fragment>,
     "stat": <React.Fragment>
-      {"id":"druid.balance.suggestions.starfire.efficiency","message":"{0} Unempowered Starfires per minute","values":{"0":"3.3"}}
+      {"id":"druid.balance.suggestions.starfire.efficiency","message":"{0} Unempowered Starfires per minute","values":{"0":"0.2"}}
        (
       0 is recommended
       )

--- a/analysis/druidbalance/src/modules/features/UnempoweredWrath.tsx
+++ b/analysis/druidbalance/src/modules/features/UnempoweredWrath.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import Analyzer, { Options, SELECTED_PLAYER } from 'parser/core/Analyzer';
+import { ThresholdStyle, When } from 'parser/core/ParseResults';
+import SPELLS from 'common/SPELLS';
+import { SpellLink } from 'interface';
+import { t } from '@lingui/macro';
+import Events, { CastEvent, DamageEvent, ApplyBuffEvent } from 'parser/core/Events';
+
+const UNEMPOWERED_CASTS_NEEDED_FOR_EMPOWERMENT = 2;
+
+class UnempoweredWrath extends Analyzer {
+  get badCastsPerMinute() {
+    return ((this.badCasts - (this.eclipseCount * UNEMPOWERED_CASTS_NEEDED_FOR_EMPOWERMENT)) / (this.owner.fightDuration / 1000)) * 60;
+  }
+
+  get suggestionThresholds() {
+    return {
+      actual: this.badCastsPerMinute,
+      isGreaterThan: {
+        minor: 0,
+        average: 1,
+        major: 2,
+      },
+      style: ThresholdStyle.NUMBER,
+    };
+  }
+
+  badCasts = 0;
+  lastCast?: CastEvent;
+  lastCastBuffed = false;
+  hits = 0;
+  eclipseCount = 0;
+
+  constructor(options: Options) {
+    super(options);
+    this.addEventListener(Events.cast.by(SELECTED_PLAYER).spell(SPELLS.WRATH_MOONKIN), this.onCast);
+    this.addEventListener(Events.damage.by(SELECTED_PLAYER).spell(SPELLS.WRATH_MOONKIN), this.onDamage);
+    this.addEventListener(Events.applybuff.to(SELECTED_PLAYER).spell(SPELLS.ECLIPSE_SOLAR), this.onApplyBuff);
+    this.addEventListener(Events.fightend, this.onFightend);
+  }
+
+  checkCast() {
+    if (this.lastCastBuffed || !this.lastCast) {
+      return;
+    }
+    this.badCasts += 1;
+    this.lastCast.meta = this.lastCast.meta || {};
+    this.lastCast.meta.isInefficientCast = true;
+    this.lastCast.meta.inefficientCastReason = `Wrath was cast without Solar Eclipse.`;
+  }
+
+  onApplyBuff(event: ApplyBuffEvent) {
+    this.eclipseCount += 1;
+  }
+
+  onCast(event: CastEvent) {
+    this.checkCast();
+    this.lastCast = event;
+    this.lastCastBuffed = this.selectedCombatant.hasBuff(SPELLS.ECLIPSE_SOLAR.id);
+    this.hits = 0;
+  }
+
+  onDamage(event: DamageEvent) {
+    this.hits += 1;
+  }
+
+  onFightend() {
+    this.checkCast();
+  }
+
+  suggestions(when: When) {
+    when(this.suggestionThresholds).addSuggestion((suggest, actual, recommended) => suggest(<>You casted {this.badCasts} unempowered <SpellLink id={SPELLS.WRATH_MOONKIN.id} /> outside the {UNEMPOWERED_CASTS_NEEDED_FOR_EMPOWERMENT} needed to get to <SpellLink id={SPELLS.ECLIPSE_SOLAR.id} /></>)
+      .icon(SPELLS.WRATH_MOONKIN.icon)
+      .actual(t({
+        id: "druid.balance.suggestions.wrath.efficiency",
+        message: `${actual.toFixed(1)} Unempowered Wraths per minute`
+      }))
+
+      .recommended(`${recommended} is recommended`));
+  }
+}
+
+export default UnempoweredWrath;


### PR DESCRIPTION
Add modules for Starfire/Wrath to track empowered casts.
It will take into account that there is always two empowered casts needed to get into eclipse.